### PR TITLE
close eldap connection if conn is not verified

### DIFF
--- a/lib/exldap.ex
+++ b/lib/exldap.ex
@@ -61,7 +61,9 @@ defmodule Exldap do
       {:ok, connection} ->
         case verify_credentials(connection, user_dn, password) do
           :ok -> {:ok, connection}
-          {_, message} -> {:error, message}
+          {_, message} ->
+             close(connection)
+             {:error, message}
         end
       error -> error
     end


### PR DESCRIPTION
to prevent leak of file descriptors and processes if somebody sending wrong credentials